### PR TITLE
Support setting eslint config path per workspace

### DIFF
--- a/ESLint.novaextension/extension.json
+++ b/ESLint.novaextension/extension.json
@@ -36,6 +36,11 @@
       "key": "apexskier.eslint.config.eslintPath",
       "title": "Path to ESLint executable",
       "type": "path"
+    },
+    {
+      "key": "apexskier.eslint.config.eslintConfigPath",
+      "title": "Path to ESLint configuration",
+      "type": "path"
     }
   ],
 

--- a/src/getEslintConfig.ts
+++ b/src/getEslintConfig.ts
@@ -1,0 +1,28 @@
+// returns project-specific eslint config
+export function getEslintConfig(): string | null {
+  let eslintConfigPath: string | null = null;
+  const workspaceEslintConfigPath = nova.workspace.config.get(
+    "apexskier.eslint.config.eslintConfigPath",
+    "string"
+  );
+  if (workspaceEslintConfigPath) {
+    if (nova.path.isAbsolute(workspaceEslintConfigPath)) {
+      eslintConfigPath = workspaceEslintConfigPath;
+    } else if (nova.workspace.path) {
+      eslintConfigPath = nova.path.join(
+        nova.workspace.path,
+        workspaceEslintConfigPath
+      );
+    } else {
+      nova.workspace.showErrorMessage(
+        "Save your workspace before using a relative ESLint config path."
+      );
+      return null;
+    }
+  }
+
+  if (eslintConfigPath && !nova.fs.access(eslintConfigPath, nova.fs.R_OK)) {
+    return null;
+  }
+  return eslintConfigPath;
+}

--- a/src/process.ts
+++ b/src/process.ts
@@ -17,7 +17,7 @@ nova.workspace.config.onDidChange(
 );
 +nova.workspace.config.onDidChange(
   "apexskier.eslint.config.eslintConfigPath",
-  async () => {
+  () => {
     eslintConfigPath = getEslintConfig();
     console.log("Updating ESLint config for workspace", eslintConfigPath);
   }

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,7 +1,9 @@
 import type { Linter } from "eslint";
 import { getEslintPath } from "./getEslintPath";
+import { getEslintConfig } from "./getEslintConfig";
 
 let eslintPath: string | null = null;
+let eslintConfigPath: string | null = null;
 nova.config.onDidChange("apexskier.eslint.config.eslintPath", async () => {
   eslintPath = await getEslintPath();
   console.log("Updating ESLint executable globally", eslintPath);
@@ -13,8 +15,16 @@ nova.workspace.config.onDidChange(
     console.log("Updating ESLint executable for workspace", eslintPath);
   }
 );
++nova.workspace.config.onDidChange(
+  "apexskier.eslint.config.eslintConfigPath",
+  async () => {
+    eslintConfigPath = getEslintConfig();
+    console.log("Updating ESLint config for workspace", eslintConfigPath);
+  }
+);
 (async () => {
   eslintPath = await getEslintPath();
+  eslintConfigPath = getEslintConfig();
 })();
 
 const filePrefixRegex = /^file:/;
@@ -37,6 +47,7 @@ export function runEslint(
     return disposable;
   }
   const eslint = eslintPath;
+  const eslintConfig = eslintConfigPath;
   const workspacePath = nova.workspace.path;
   const cleanFileName = decodeURI(uri).replace(filePrefixRegex, "");
 
@@ -81,8 +92,17 @@ export function runEslint(
     // eslint-disable-next-line no-unused-vars
     callback: (issues: ReadonlyArray<Linter.LintMessage>) => void
   ): void {
+    const lintArgs = [
+      "--format=json",
+      "--stdin",
+      "--stdin-filename",
+      cleanFileName,
+    ];
+    if (eslintConfig) {
+      lintArgs.unshift("--config", eslintConfig);
+    }
     const lintProcess = new Process(eslint, {
-      args: ["--format=json", "--stdin", "--stdin-filename", cleanFileName],
+      args: lintArgs,
       cwd: workspacePath,
       stdio: "pipe",
     });


### PR DESCRIPTION
This is my attempt to address #58. Users can set the path to an eslint configuration file in the workspace preferences. If found, `eslint` will be called with the `--config` option and the path to the defined configuration file.  